### PR TITLE
商品情報編集機能+ブランチ作成忘れ

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -40,7 +40,7 @@ class ItemsController < ApplicationController
 
 
   private
-
+  #ブランチ作成忘れ後のコミット用
   def can_edit_item?(item)
     current_user && current_user.id == item.user_id
   end


### PR DESCRIPTION
# What
・editおよびupdateアクションおよびルーティング設定
・editビュー編集
※下記機能は商品購入機能実装後に実装
　・ログイン状態で自身が出品した売却済み商品の商品情報編集ページへ
　　遷移しようとすると、トップページに遷移

# Why
・商品情報編集機能実装

# Reference
・ログイン時に商品情報編集ページに遷移
　かつ登録済情報が既に表示されている
https://gyazo.com/8cbbea03fdccc3e83a2d4dca99a9ac56

・商品情報編集成功
https://gyazo.com/2ca2b72a6503791c1c2742e882fca6c9

・入力に問題がある状態では商品情報編集不可
https://gyazo.com/563ffd787928165d43e7bfc8c3980982

・無編集で「更新する」ボタンを押しても画像無しの商品にならない
https://gyazo.com/5f4645d7bfc4860384f6acedaca4f298

・ログイン状態でも、URL直接入力で他人の商品情報編集に遷移不可
https://gyazo.com/21ea75909f92228ed9ddb06db4a2b89a

・ログアウト状態で、URLを直接入力して商品情報編集に遷移不可かつログインページへ遷移
https://gyazo.com/9ad75b9607ef7fd958ba976c72ad6592

※メインブランチのままコードを記載してしまったため、一度スタッシュ処理を実施しています。
　主なcommitは「商品情報編集機能実装」commitの内容となります。